### PR TITLE
Merge array values when merging annotation properties

### DIFF
--- a/src/Annotations/AbstractAnnotation.php
+++ b/src/Annotations/AbstractAnnotation.php
@@ -204,6 +204,10 @@ abstract class AbstractAnnotation implements JsonSerializable
                 $this->_unmerged = array_merge($this->_unmerged, $value);
                 continue;
             }
+            if (is_array($currentValues[$property]) && is_array($value)) {
+                $this->$property = array_merge($currentValues[$property], $value);
+                continue;
+            }
             if ($currentValues[$property] !== $value) { // New value is not the same?
                 if ($defaultValues[$property] === $value) { // but is the same as the default?
                     continue; // Keep current, no notice


### PR DESCRIPTION
This allows annotations that will be merged to have all the values of the property in both annotations

One usage is multiple `@Swagger` definitions which each have parameters or responses. My application is that I'm autogenerating operation annotations based on metadata from my framework, and this allows parameters in these autogenerated annotations to be merged with manually declared options for that operation.